### PR TITLE
simplify configure, add basic cuda instructions

### DIFF
--- a/configure
+++ b/configure
@@ -1,26 +1,19 @@
 #!/bin/bash
 # Shell config script
 
-CC=`${R_HOME}/bin/R CMD config CC`
-CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
-CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
+LIBTORCH="/usr/local/lib/libtorch"
 
-PKG_CFLAGS="-I/usr/local/lib/libtorch/include -I/usr/local/lib/libtorch/include/torch/csrc/api/include"
+PKG_CFLAGS="-I$LIBTORCH/include -I/$LIBTORCH/include/torch/csrc/api/include"
+PKG_LIBS="-L$LIBTORCH/lib -Wl,-rpath,$LIBTORCH/lib -ltorch"
 
-PKG_LIBS="-L/usr/local/lib/libtorch/lib -Wl,-rpath,/usr/local/lib/libtorch/lib -ltorch"
-
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  echo "---------Linux detected----------------"
-  PKG_LIBS="$PKG_LIBS /usr/local/lib/libtorch/lib/libtorch.so /usr/local/lib/libtorch/lib/libcaffe2.so /usr/local/lib/libtorch/lib/libc10.so"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  echo "---------MacOS detected----------------"
-  PKG_LIBS="$PKG_LIBS /usr/local/lib/libtorch/lib/libtorch.dylib /usr/local/lib/libtorch/lib/libcaffe2.dylib /usr/local/lib/libtorch/lib/libc10.dylib"
-fi
+# uncomment to install torch with CUDA support
+#LIBCUDA="/usr/local/cuda-9.0"
+#PKG_LIBS="-L$LIBTORCH/lib -Wl,-rpath,$LIBTORCH/lib -ltorch -L/$LIBCUDA/lib -lnvrtc -lcuda"
 
 echo "Using PKG_LIBS=$PKG_LIBS"
 echo "Using PKG_CFLAGS=$PKG_CFLAGS"
 
 # Write to Makevars
-sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" src/Makevars.in > src/Makevars
+sed -e "s|@pkg_cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" src/Makevars.in > src/Makevars
 
 exit 0

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,4 +1,4 @@
-CXX=clang++
-PKG_CPPFLAGS=@cflags@
+# https://discuss.pytorch.org/t/undefined-symbol-when-import-lltm-cpp-extension/32627
+PKG_CPPFLAGS=@pkg_cflags@ -D_GLIBCXX_USE_CXX11_ABI=0
 PKG_LIBS=@libs@
 CXX_STD=CXX11


### PR DESCRIPTION
- remove CXX from pkg Makevars (usually should be in user `~/.R/Makevars`)
- add `-D_GLIBCXX_USE_CXX11_ABI=0` because of [this issue](https://discuss.pytorch.org/t/undefined-symbol-when-import-lltm-cpp-extension/32627) - I had challenges with installing it on ubuntu 16.04 with g++ 5.4.0
- simplify configure
- add comment about cuda recipe to configure (compiles fine, but not tested tensors on GPU)